### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -4,12 +4,6 @@ class ItemsController < ApplicationController
 
   def index
     @items = Item.all.order('created_at DESC')
-    payments = PaymentMethod.all
-
-    @payment_methods = ['']
-    payments.each do |payment|
-      @payment_methods.push(payment.name)
-    end
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,6 +3,13 @@ class ItemsController < ApplicationController
   # before_action :move_to_index, only: [:edit]
 
   def index
+    @items = Item.all.order("created_at DESC")
+    payments = PaymentMethod.all
+
+    @payment_methods = ['']
+    payments.each do |payment|
+      @payment_methods.push(payment.name)
+    end
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,7 +3,7 @@ class ItemsController < ApplicationController
   # before_action :move_to_index, only: [:edit]
 
   def index
-    @items = Item.all.order("created_at DESC")
+    @items = Item.all.order('created_at DESC')
     payments = PaymentMethod.all
 
     @payment_methods = ['']

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,7 +128,6 @@
     </div>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <% if @items.length > 0 %>
         <% @items.each do |item| %>
           <li class='list'>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,36 +129,36 @@
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
-
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
-
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+      <% if @items.length > 0 %>
+        <% @items.each do |item| %>
+          <li class='list'>
+            <%= link_to "#" do %>
+            <div class='item-img-content'>
+              <%= image_tag item.image, class: "item-img" %>
+              <%# 商品が売れていればsold outを表示しましょう %>
+              <%# <div class='sold-out'> %>
+                <%# <span>Sold Out!!</span> %>
+              <%# </div> %> 
+              <%# //商品が売れていればsold outを表示しましょう %>
             </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+            <% end %>
+            <div class='item-info'>
+              <h3 class='item-name'>
+                <%= item.name %>
+              </h3>
+              <div class='item-price'>
+                <span><%= item.selling_price %>円<br><%= @payment_methods[item.payment_method_id] %></span>
+                <div class='star-btn'>
+                  <%= image_tag "star.png", class:"star-icon" %>
+                  <span class='star-count'>0</span>
+                </div>
+              </div>
+            </div>
+          <% end %>
+        </li>
 
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+      <% else %>
+
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -176,8 +176,7 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+      <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -146,7 +146,7 @@
                 <%= item.name %>
               </h3>
               <div class='item-price'>
-                <span><%= item.selling_price %>円<br><%= @payment_methods[item.payment_method_id] %></span>
+                <span><%= item.selling_price %>円<br><%= item.payment_method.name %></span>
                 <div class='star-btn'>
                   <%= image_tag "star.png", class:"star-icon" %>
                   <span class='star-count'>0</span>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root to: "items#index"
-  resources :items, only: [:new, :create]
+  resources :items, only: [:index, :new, :create]
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe Item, type: :model do
       it 'selling_priceが小数点以下を持つ場合登録できない' do
         @item.selling_price = 300.5
         @item.valid?
-        expect(@item.errors.full_messages).to include("Selling price must be an integer")
+        expect(@item.errors.full_messages).to include('Selling price must be an integer')
       end
 
       it 'selling_priceが全角入力(ひらがな)では登録できない' do


### PR DESCRIPTION
# What
商品一覧をトップ画面に表示する機能を追加。

# Why
ユーザーが商品を一覧として見ることができるようにするため。

# エビデンス
- 商品のデータがない場合は、ダミー商品が表示されている動画
https://gyazo.com/89c3f98b408b6581101b57f690b66010
- 商品のデータがある場合は、商品が一覧で表示されている動画（2つ以上の商品が出品されている状態を撮影してください。表示順を確かめるためです）
https://gyazo.com/262f65982422636d8fc5ec4b59c12353

#補足事項
- Sold Outの表示機能は、現時点で実装が困難と考え、ソースコードをコメントアウトして残しています。